### PR TITLE
do not pass params to execute if it is None

### DIFF
--- a/lib/ingres_sa_dialect/base.py
+++ b/lib/ingres_sa_dialect/base.py
@@ -522,7 +522,10 @@ class IngresDialect(default.DefaultDialect):
         rs = None
         
         try:
-            rs = connection.execute(sqltext, params)
+            if params:
+                rs = connection.execute(sqltext, params)
+            else:
+                rs = connection.execute(sqltext)
             
             return [row[0].rstrip() for row in rs.fetchall()]
         finally:


### PR DESCRIPTION
Just like in other places, the case that `params` is not set needs to be handled when calling execute. 
