### PR TITLE
…

### DIFF
--- a/lib/ingres_sa_dialect/base.py
+++ b/lib/ingres_sa_dialect/base.py
@@ -375,7 +375,11 @@ class IngresDialect(default.DefaultDialect):
         finally:
             if rs:
                 rs.close()
-                
+
+    @reflection.cache
+    def get_pk_constraint(self, connection, table_name, schema=None, **kw):
+        return self.get_primary_keys(connection, table_name, schema, **kw)
+
     @reflection.cache
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
         sqltext = """


### PR DESCRIPTION
Get_primary_keys is deprecated since SQLAlchemy version 0.8 and replaced by get_pk_constraints. (See [Link](https://www.kite.com/python/docs/sqlalchemy.engine.reflection.Inspector.get_primary_keys)). 
Creating a wrapper might be the best option to be compatible with older and newer SQLAlchemy versions. This is used by pandas' read_sql_table function.